### PR TITLE
[IOCOM-2002] fix(fims): use continua.io instead io.italia.it

### DIFF
--- a/FimsAccessExport/__tests__/__snapshots__/index.test.ts.snap
+++ b/FimsAccessExport/__tests__/__snapshots__/index.test.ts.snap
@@ -403,7 +403,7 @@ p {
                align="center" bgcolor="#0073E6" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:11px 20px;background:#0073E6;" valign="middle"
             >
               <a
-                 href="https://io.italia.it" style="display:inline-block;background:#0073E6;color:white;font-family:Titillium Web, system-ui, sans-serif;font-size:14px;font-weight:bold;line-height:18px;margin:0;text-decoration:none;text-transform:none;padding:11px 20px;mso-padding-alt:0px;border-radius:4px;" target="_blank"
+                 href="https://continua.io.pagopa.it" style="display:inline-block;background:#0073E6;color:white;font-family:Titillium Web, system-ui, sans-serif;font-size:14px;font-weight:bold;line-height:18px;margin:0;text-decoration:none;text-transform:none;padding:11px 20px;mso-padding-alt:0px;border-radius:4px;" target="_blank"
               >
                 Vai su IO
               </a>

--- a/FimsAccessExport/index.mjml
+++ b/FimsAccessExport/index.mjml
@@ -77,7 +77,7 @@
               align="left"
               inner-padding="11px 20px"
               border-radius="4px"
-              href="https://io.italia.it"
+              href="https://continua.io.pagopa.it"
               css-class="cta"
               padding-left="0px"
               padding-right="0px"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
1. FimsAccessExport: replace the href of the CTA to use `https://continua.io.pagopa.it` instead `https://io.italia.it`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`https://continua.io.pagopa.it` is a dynamic link that opens the IO App when opened in mobile devices and the IO App Website otherwise.
